### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Build stage
+FROM golang:1.21-alpine AS builder
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy go.mod and go.sum files first for dependency resolution
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy the entire source code into the container
+COPY . .
+
+# Build the binary for Linux
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/mcp-wecombot-server_linux_amd64 .
+
+# Final stage
+FROM alpine:latest
+
+# Set working directory
+WORKDIR /app
+
+# Copy the compiled binary from the builder stage
+COPY --from=builder /app/dist/mcp-wecombot-server_linux_amd64 /usr/local/bin/mcp-wecombot-server
+
+# Expose any ports the application requires, if necessary
+# EXPOSE <port>
+
+# Set the entrypoint to the compiled binary
+ENTRYPOINT ["mcp-wecombot-server"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 ## 🚀 mcp-wecombot-server
+[![smithery badge](https://smithery.ai/badge/@gotoolkits/mcp-wecombot-server)](https://smithery.ai/server/@gotoolkits/mcp-wecombot-server)
 
 An MCP server application that sends various types of messages to the WeCom group robot.
 
 ### Installation
 
+### Installing via Smithery
+
+To install mcp-wecombot-server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@gotoolkits/mcp-wecombot-server):
+
+```bash
+npx -y @smithery/cli install @gotoolkits/mcp-wecombot-server --client claude-desktop
+```
+
+### Manual Installation
 ```sh
 # clone the repo and build
 $ git clone https://github.com/gotoolkits/mcp-wecombot-server.git

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - wecomBotWebhookKey
+    properties:
+      wecomBotWebhookKey:
+        type: string
+        description: The webhook key for the WeCom Bot server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'mcp-wecombot-server', env: { WECOM_BOT_WEBHOOK_KEY: config.wecomBotWebhookKey } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai?utm_campaign=pr) to render configurations for the end-user. It also allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@gotoolkits/mcp-wecombot-server?utm_campaign=pr&modal=claim), claiming it and clicking "Deploy".
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. Note that the installation only works after the server is deployed.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂